### PR TITLE
Add conda packages from whw waterdata (Tue) tutorials

### DIFF
--- a/singleuser/waterhackweek/Dockerfile
+++ b/singleuser/waterhackweek/Dockerfile
@@ -16,9 +16,10 @@ ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
 
 # WHW Dependencies
 RUN conda create -n whw -y \
-python=3.6 \
+python \
 ipython \
 ipykernel \
+nb_conda_kernels \
 requests \
 geopandas \
 descartes \
@@ -26,13 +27,20 @@ geojson \
 rasterio \
 netcdf4 \
 xarray \
+rioxarray \
+regionmask \
 dask \
 ulmo \
+hydrodata \
 owslib \
+boto3 \
+s3fs \
+zarr \
 matplotlib \
 seaborn \
 cartopy \
 folium \
+contextily \
 xlrd \
 && conda clean --all -f -y
 


### PR DESCRIPTION
- These addition bring the base env in line with the current https://github.com/waterhackweek/waterdata/blob/master/environment.yml
- Removed Python pinning to 3.6, though I suspect a dependency for ulmo will result in Python 3.6 (I'm working on it!)
- Other packages should be considered, beyond ones supporting the Tuesday Tutorials. eg: landlab, metpy, siphon, intake

cc @Castronova 