### PR TITLE
Pin pandas to <1.1 and add intake, landlab, metpy and holoviz packages

### DIFF
--- a/singleuser/waterhackweek/Dockerfile
+++ b/singleuser/waterhackweek/Dockerfile
@@ -21,6 +21,7 @@ ipython \
 ipykernel \
 nb_conda_kernels \
 requests \
+pandas<1.1 \
 geopandas \
 descartes \
 geojson \

--- a/singleuser/waterhackweek/Dockerfile
+++ b/singleuser/waterhackweek/Dockerfile
@@ -33,16 +33,28 @@ regionmask \
 dask \
 ulmo \
 hydrodata \
+intake \
+metpy \
+landlab \
 owslib \
 boto3 \
 s3fs \
 zarr \
+xlrd \
 matplotlib \
 seaborn \
 cartopy \
 folium \
 contextily \
-xlrd \
+# holoviz packages
+bokeh \
+colorcet \
+datashader \
+geoviews \
+holoviews \
+hvplot \
+panel \
+param \
 && conda clean --all -f -y
 
 RUN pip install "jupyterlab>=1.0" jupyterlab-dash==0.1.0a3


### PR DESCRIPTION
Pinning pandas to <1.1 due to incompatibilities with ulmo (and probably other packages). Specifically, `ncdc.ghcn_daily.get_data` data parsing (and likely other ulmo readers). One of our Tuesday tutorials fails with ulmo used with pandas >=1.1. There may be other incompatibility issues with use of pandas >= 1.1 out there, too, with other packages.

https://github.com/ulmo-dev/ulmo/issues/195

cc @Castronova 