### PR TITLE
Hydroshare on jupyter config fix

### DIFF
--- a/singleuser/base/Dockerfile.base
+++ b/singleuser/base/Dockerfile.base
@@ -104,6 +104,10 @@ RUN echo 'cd $HOME' >> .profile
 RUN pip install hydroshare-on-jupyter==0.1.0 && \
   python -m hydroshare_on_jupyter configure
 
+# set hydroshare_on_jupyter configuration env variables
+ENV DATA=${HOME}/downloads
+ENV OAUTH=${HOME}/.hs_auth
+
 # copy hydroshare on jupyter config file
 COPY ./hydroshare_on_jupyter_conf ${HOME}/.config/hydroshare_on_jupyter/config
 

--- a/singleuser/base/Dockerfile.base
+++ b/singleuser/base/Dockerfile.base
@@ -108,9 +108,6 @@ RUN pip install hydroshare-on-jupyter==0.1.0 && \
 ENV DATA=${HOME}/downloads
 ENV OAUTH=${HOME}/.hs_auth
 
-# copy hydroshare on jupyter config file
-COPY ./hydroshare_on_jupyter_conf ${HOME}/.config/hydroshare_on_jupyter/config
-
 # remove work dir b/c we're using "data"
 RUN rm -rf ~/work
 

--- a/singleuser/base/README.md
+++ b/singleuser/base/README.md
@@ -3,7 +3,8 @@
 
 This is the base singleuser image for the CUAHSI JupyterHub platform. The purpose of this image is to establish a basic (and small) environment that provides integration with HydroShare, that can be extended to derived more complex images. Below are the primary tools and libraries included in this environment:
 
-1. `hs_restclient`: A python library for interfacing with HydroShare's web API - [hs_restclient repository](https://github.com/hydroshare/hs_restclient)   
-2. `iCommands`: A command-line toolset for working with iRODs - [icommands documentation](https://docs.irods.org/master/icommands/user/)   
-3. `TauDEM`: A suite of digital elevation model tools for hydrologic analysis - [TauDEM homepage](http://hydrology.usu.edu/taudem/taudem5/index.html)
+1. `hsclient`: A python client for interacting with HydroShare in an object oriented way - [repo](https://github.com/hydroshare/hsclient/).
+1. `hydroshare_on_jupyter`: JupyterLab plugin for interacting with HydroShare resources within JupyterLab's development environment - [repo](https://github.com/hydroshare/hydroshare_jupyter_sync). 
+1. `iCommands`: A command-line toolset for working with iRODs - [icommands documentation](https://docs.irods.org/master/icommands/user/)   
+1. `TauDEM`: A suite of digital elevation model tools for hydrologic analysis - [TauDEM homepage](http://hydrology.usu.edu/taudem/taudem5/index.html)
 

--- a/singleuser/base/hydroshare_on_jupyter_conf
+++ b/singleuser/base/hydroshare_on_jupyter_conf
@@ -1,3 +1,0 @@
-DATA=~/downloads
-OAUTH=~/.hs_auth
-


### PR DESCRIPTION
move `hydroshare_on_jupyter`'s config into singleuser base dockerfile via environment variables.
remove `hydroshare_on_jupyter`'s config file from repo and no longer copy it into image.