### PR TITLE
Build images via GH Actions

### DIFF
--- a/.github/workflows/periodic-image-build.yml
+++ b/.github/workflows/periodic-image-build.yml
@@ -9,7 +9,7 @@ env:
   REGISTRY_HOSTNAME: docker.io
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  REPOSITORY: cuahsi
+  REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
 
 on:
   schedule:
@@ -38,17 +38,6 @@ jobs:
         uses: xom9ikk/dotenv@v2
         with:
           path: ${{ env.IMAGE_ROOT }}
-
-      - name: Echo env configuration and set image tag
-        id: tagging
-        run: |
-          echo "JH_BASE: ${{ env.JH_BASE }}"
-          echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
-          echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
-          echo ------------
-          export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
-          echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
-          echo $DOCKER_FULL_PATH
       
       - name: Docker Login
         run: |
@@ -59,9 +48,21 @@ jobs:
         run: |
           cd "${IMAGE_ROOT}"
           docker compose build ${{ matrix.IMAGE_VARIANT }}
+      
+      - name: Echo env configuration and set image tag
+        id: tagging
+        run: |
+          echo "JH_BASE: ${{ env.JH_BASE }}"
+          echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
+          echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
+          echo ------------
+          export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
+          echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
+          echo $DOCKER_FULL_PATH
+          docker tag ${{ env.DOCKER_FULL_PATH }} ${{ env.DOCKER_FULL_PATH }}-periodic-$(date +'%Y-%m-%d')
 
       - name: Push Docker Image
         run: |
-          docker push ${{ env.DOCKER_FULL_PATH }}
+          docker push ${{ env.DOCKER_FULL_PATH }}-periodic-$(date +'%Y-%m-%d')
 
     # TODO: run tests?

--- a/.github/workflows/periodic-image-build.yml
+++ b/.github/workflows/periodic-image-build.yml
@@ -52,7 +52,7 @@ jobs:
       
       - name: Docker Login
         run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USER --password-stdin
 
       # Build the Docker image
       - name: Build

--- a/.github/workflows/periodic-image-build.yml
+++ b/.github/workflows/periodic-image-build.yml
@@ -12,9 +12,6 @@ on:
     - cron: '0 0 * * 0'  # At 00:00 every Sunday
 
   workflow_dispatch:
-    inputs:
-      stacks-ref:
-        description: 'Ref to use from cuahsi-stacks'
 
 jobs:
   setup-build-publish-deploy:
@@ -35,13 +32,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        if: github.event.inputs.stacks-ref == ''
+        if: ${{ github.event.action }} != 'workflow_dispatch'
       
-      - name: Checkout, ref = ${{ github.event.inputs.stacks-ref }}
+      - name: Checkout, ref = ${{ github.ref_name }}
         uses: actions/checkout@v2
-        if: github.event.inputs.stacks-ref != ''
+        if: ${{ github.event.action }} == 'workflow_dispatch'
         with:
-          ref: ${{ github.event.inputs.stacks-ref }}
+          ref: ${{ github.ref_name }}
 
       - name: Load .env file
         uses: xom9ikk/dotenv@v2

--- a/.github/workflows/periodic-image-build.yml
+++ b/.github/workflows/periodic-image-build.yml
@@ -1,10 +1,6 @@
 name: Periodically Build and Publish to Google Artifact Registry
-# Adapted from http://acaird.github.io/computers/2020/02/11/github-google-container-cloud-run
 
-# TODO update env for CUAHSI
 env:
-  GITHUB_SHA: ${{ github.sha }}
-  GITHUB_REF: ${{ github.ref }}
   IMAGE_ROOT: singleuser
   REGISTRY_HOSTNAME: docker.io
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
@@ -56,13 +52,14 @@ jobs:
           echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
           echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
           echo ------------
-          export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
+          export DOCKER_TAG="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
+          export DOCKER_FULL_PATH="$DOCKER_TAG-periodic-$(date +'%Y.%m.%d')"
           echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
           echo $DOCKER_FULL_PATH
-          docker tag ${{ env.DOCKER_FULL_PATH }} ${{ env.DOCKER_FULL_PATH }}-periodic-$(date +'%Y-%m-%d')
+          docker tag $DOCKER_TAG $DOCKER_FULL_PATH
 
       - name: Push Docker Image
         run: |
-          docker push ${{ env.DOCKER_FULL_PATH }}-periodic-$(date +'%Y-%m-%d')
+          docker push $DOCKER_FULL_PATH
 
     # TODO: run tests?

--- a/.github/workflows/periodic-image-build.yml
+++ b/.github/workflows/periodic-image-build.yml
@@ -1,4 +1,4 @@
-name: Build and Push to Google Artifact Registry
+name: Periodically Build and Publish to Google Artifact Registry
 # Adapted from http://acaird.github.io/computers/2020/02/11/github-google-container-cloud-run
 
 # TODO update env for G Artifact Registry project
@@ -6,25 +6,15 @@ env:
   GITHUB_SHA: ${{ github.sha }}
   GITHUB_REF: ${{ github.ref }}
   IMAGE_ROOT: singleuser
-  # TODO: eventually loop on image variant to build other services...
   # IMAGE_VARIANT: base
-  # periodically build a core set: base, scientific, r, summa, wrfhydro, csdms
-  # other envs on the JH launch page should also build periodically
-  # maybe all the others: we just build them and make sure they succeed but don't publih? or push to dockerhub
   REGISTRY_HOSTNAME: gcr.io
   PROJECT_ID: cuahsi-stacks-proj-id
   HOST_REGION: us-east4-docker.pkg.dev
   REPOSITORY: cuahsi
 
 on:
-  push:
-    # TODO: build periodically? or on tag?
-    # tags:
-    #   - *
-    branches: [gh-actions-build]
-    paths:
-      - "${IMAGE_ROOT}/**"
-      - ".github/workflows/**"
+  schedule:
+    - cron: '0 0 * * 0'  # At 00:00 every Sunday
 
 # Environment variables available to all jobs and steps in this workflow
 #  GKE_KEY: ${{ secrets.GKE_KEY }}
@@ -34,8 +24,8 @@ jobs:
     name: Setup, Build, and Publish
     runs-on: ubuntu-latest
     strategy:
-      continue-on-error: true
       max-parallel: 6
+      # select a core set of images to build
       matrix:
         IMAGE_VARIANT:
           - base
@@ -51,7 +41,7 @@ jobs:
       - name: Load .env file
         uses: xom9ikk/dotenv@v2
         with:
-          path: ${IMAGE_ROOT}
+          path: ${{ env.IMAGE_ROOT }}
 
       - name: Echo env configuration and set image tag
         id: tagging
@@ -82,15 +72,14 @@ jobs:
           gcloud auth configure-docker us-east4-docker.pkg.dev
 
       # Build the Docker image
-      # TODO: eventually loop on image variant to build other services...
       - name: Build
         run: |
-          cd ${IMAGE_ROOT}
+          cd "${IMAGE_ROOT}"
           docker compose build ${{ matrix.IMAGE_VARIANT }}
 
       # TODO Push the Docker image to Google Artifact Registry
-      - name: Push Docker Image to Artifact Registry
-        run: |
-          docker push $HOST_REGION/$PROJECT_ID/${{ env.DOCKER_FULL_PATH }}
+      # - name: Push Docker Image to Artifact Registry
+      #   run: |
+      #     docker push $HOST_REGION/$PROJECT_ID/${{ env.DOCKER_FULL_PATH }}
 
     # TODO: run tests?

--- a/.github/workflows/periodic-image-build.yml
+++ b/.github/workflows/periodic-image-build.yml
@@ -1,4 +1,4 @@
-name: Periodically Build and Publish to Google Artifact Registry
+name: Periodically Build and Publish to Registry
 
 env:
   IMAGE_ROOT: singleuser
@@ -11,10 +11,16 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # At 00:00 every Sunday
 
+  workflow_dispatch:
+    inputs:
+      stacks-ref:
+        description: 'Ref to use from cuahsi-stacks'
+
 jobs:
   setup-build-publish-deploy:
     name: Setup, Build, and Publish
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       max-parallel: 6
       # select a core set of images to build
@@ -29,6 +35,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        if: github.event.inputs.stacks-ref == ''
+      
+      - name: Checkout, ref = ${{ github.event.inputs.stacks-ref }}
+        uses: actions/checkout@v2
+        if: github.event.inputs.stacks-ref != ''
+        with:
+          ref: ${{ github.event.inputs.stacks-ref }}
 
       - name: Load .env file
         uses: xom9ikk/dotenv@v2

--- a/.github/workflows/singleuser.yml
+++ b/.github/workflows/singleuser.yml
@@ -1,0 +1,87 @@
+name: Build and Push to GCR
+
+on:
+  push:
+    # tags:
+    #   - *
+    # TODO: run on tag publish
+    branches: [ gh-actions-build ]
+
+# Environment variables available to all jobs and steps in this workflow
+#  GKE_KEY: ${{ secrets.GKE_KEY }} 
+
+# TODO update env for G Artifact Registry project
+env:
+  GITHUB_SHA: ${{ github.sha }} 
+  GITHUB_REF: ${{ github.ref }} 
+  IMAGE: dendra-web-ui
+  REGISTRY_HOSTNAME: gcr.io
+  PROJECT_ID: cuahsi-stacks-proj-id
+  HOST_REGION: us-east4-docker.pkg.dev
+  REPOSITORY: cuahsi-stacks-repo
+
+
+jobs:
+  setup-build-publish-deploy:
+    name: Setup, Build, and Publish
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+    
+    # TODO: enable google auth and add secrets to GH
+    # - id: 'auth'
+    #   uses: 'google-github-actions/auth@v1'
+    #   with:
+    #     credentials_json: '${{ secrets.GKE_KEY }}'
+
+    # - name: 'Set up Cloud SDK'
+    #   uses: 'google-github-actions/setup-gcloud@v1'
+
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker --quiet
+        gcloud auth configure-docker us-east4-docker.pkg.dev
+
+    # Build the Docker image
+    # - name: Build
+    #   run: |
+    #     export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+    #     echo $TAG
+    #     docker build -t $IMAGE:latest \
+    #       --build-arg GITHUB_SHA="$GITHUB_SHA" \
+    #       --build-arg GITHUB_REF="$GITHUB_REF" \
+    #       -f Dockerfile-cuahsi .
+
+    # TODO: eventually we will build other services...
+    - name: Build
+      run: |
+        cd singleuser
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker compose build base
+
+
+    # Push the Docker image to Google Container Registry
+    # - name: Publish
+    #   run: |
+    #     export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+    #     echo $TAG
+    #     docker tag $IMAGE:latest $REGISTRY_HOSTNAME/$PROJECT_ID/$IMAGE:latest
+    #     docker tag $IMAGE:latest $REGISTRY_HOSTNAME/$PROJECT_ID/$IMAGE:$TAG
+    #     docker push $REGISTRY_HOSTNAME/$PROJECT_ID/$IMAGE:latest
+    #     docker push $REGISTRY_HOSTNAME/$PROJECT_ID/$IMAGE:$TAG
+    
+    # TODO Push the Docker image to Google Artifact Registry
+    # - name: Push Docker Image to Artifact Registry
+    #   run: |
+    #     export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+    #     echo $TAG
+    #     docker tag $IMAGE:latest $HOST_REGION/$PROJECT_ID/$REPOSITORY/$IMAGE:latest
+    #     docker tag $IMAGE:latest $HOST_REGION/$PROJECT_ID/$REPOSITORY/$IMAGE:$TAG
+    #     docker push $HOST_REGION/$PROJECT_ID/$REPOSITORY/$IMAGE:latest
+    #     docker push $HOST_REGION/$PROJECT_ID/$REPOSITORY/$IMAGE:$TAG

--- a/.github/workflows/singleuser.yml
+++ b/.github/workflows/singleuser.yml
@@ -3,11 +3,14 @@ name: Build and Push to Google Artifact Registry
 
 # TODO update env for G Artifact Registry project
 env:
-  GITHUB_SHA: ${{ github.sha }} 
+  GITHUB_SHA: ${{ github.sha }}
   GITHUB_REF: ${{ github.ref }}
   IMAGE_ROOT: singleuser
   # TODO: eventually loop on image variant to build other services...
-  IMAGE_VARIANT: base
+  # IMAGE_VARIANT: base
+  # periodically build a core set: base, scientific, r, summa, wrfhydro, csdms
+  # other envs on the JH launch page should also build periodically
+  # maybe all the others: we just build them and make sure they succeed but don't publih? or push to dockerhub
   REGISTRY_HOSTNAME: gcr.io
   PROJECT_ID: cuahsi-stacks-proj-id
   HOST_REGION: us-east4-docker.pkg.dev
@@ -18,67 +21,75 @@ on:
     # TODO: build periodically? or on tag?
     # tags:
     #   - *
-    branches: [ gh-actions-build ]
+    branches: [gh-actions-build]
     paths:
       - "singleuser/**"
       - ".github/workflows/**"
 
 # Environment variables available to all jobs and steps in this workflow
-#  GKE_KEY: ${{ secrets.GKE_KEY }} 
-
+#  GKE_KEY: ${{ secrets.GKE_KEY }}
 
 jobs:
   setup-build-publish-deploy:
     name: Setup, Build, and Publish
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 6
+      matrix:
+        IMAGE_VARIANT:
+          - base
+          - scientific
+          - r
+          - summa
+          - wrfhydro
+          - csdms
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Checkout
-      uses: actions/checkout@v2
-    
-    - name: Load .env file
-      uses: xom9ikk/dotenv@v2
-      with:
-        path: singleuser
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v2
+        with:
+          path: singleuser
 
-    - name: Echo env configuration and set image tag
-      id: tagging
-      run: |
-        echo "JH_BASE: ${{ env.JH_BASE }}"
-        echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
-        echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
-        echo ------------
-        # export DOCKER_FULL_PATH="singleuser-base-${{ env.BUILD_DATE }}-$(echo ${GITHUB_REF} | cut -d'/' -f3)-${GITHUB_SHA}"
-        export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${IMAGE_VARIANT}:${{ env.CUAHSI_BASE }}"
-        echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
-        echo $DOCKER_FULL_PATH
+      - name: Echo env configuration and set image tag
+        id: tagging
+        run: |
+          echo "JH_BASE: ${{ env.JH_BASE }}"
+          echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
+          echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
+          echo ------------
+          # export DOCKER_FULL_PATH="singleuser-base-${{ env.BUILD_DATE }}-$(echo ${GITHUB_REF} | cut -d'/' -f3)-${GITHUB_SHA}"
+          export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
+          echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
+          echo $DOCKER_FULL_PATH
 
+      # TODO: enable google auth and add secrets to GH
+      # - id: 'auth'
+      #   uses: 'google-github-actions/auth@v1'
+      #   with:
+      #     credentials_json: '${{ secrets.GKE_KEY }}'
 
-    # TODO: enable google auth and add secrets to GH
-    # - id: 'auth'
-    #   uses: 'google-github-actions/auth@v1'
-    #   with:
-    #     credentials_json: '${{ secrets.GKE_KEY }}'
+      # - name: 'Set up Cloud SDK'
+      #   uses: 'google-github-actions/setup-gcloud@v1'
 
-    # - name: 'Set up Cloud SDK'
-    #   uses: 'google-github-actions/setup-gcloud@v1'
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: |
+          # Set up docker to authenticate
+          # via gcloud command-line tool.
+          gcloud auth configure-docker --quiet
+          gcloud auth configure-docker us-east4-docker.pkg.dev
 
+      # Build the Docker image
+      # TODO: eventually loop on image variant to build other services...
+      - name: Build
+        run: |
+          cd singleuser
+          docker compose build ${{ matrix.IMAGE_VARIANT }}
 
-    # Configure docker to use the gcloud command-line tool as a credential helper
-    - run: |
-        # Set up docker to authenticate
-        # via gcloud command-line tool.
-        gcloud auth configure-docker --quiet
-        gcloud auth configure-docker us-east4-docker.pkg.dev
+      # TODO Push the Docker image to Google Artifact Registry
+      - name: Push Docker Image to Artifact Registry
+        run: |
+          docker push $HOST_REGION/$PROJECT_ID/${{ env.DOCKER_FULL_PATH }}
 
-    # Build the Docker image
-    # TODO: eventually loop on image variant to build other services...
-    - name: Build
-      run: |
-        cd singleuser
-        docker compose build $IMAGE_VARIANT
-    
-    # TODO Push the Docker image to Google Artifact Registry
-    - name: Push Docker Image to Artifact Registry
-      run: |
-        docker push $HOST_REGION/$PROJECT_ID/${{ env.DOCKER_FULL_PATH }}
+    # TODO: run tests?

--- a/.github/workflows/singleuser.yml
+++ b/.github/workflows/singleuser.yml
@@ -23,7 +23,7 @@ on:
     #   - *
     branches: [gh-actions-build]
     paths:
-      - "singleuser/**"
+      - "${IMAGE_ROOT}/**"
       - ".github/workflows/**"
 
 # Environment variables available to all jobs and steps in this workflow
@@ -34,6 +34,7 @@ jobs:
     name: Setup, Build, and Publish
     runs-on: ubuntu-latest
     strategy:
+      continue-on-error: true
       max-parallel: 6
       matrix:
         IMAGE_VARIANT:
@@ -50,7 +51,7 @@ jobs:
       - name: Load .env file
         uses: xom9ikk/dotenv@v2
         with:
-          path: singleuser
+          path: ${IMAGE_ROOT}
 
       - name: Echo env configuration and set image tag
         id: tagging
@@ -84,7 +85,7 @@ jobs:
       # TODO: eventually loop on image variant to build other services...
       - name: Build
         run: |
-          cd singleuser
+          cd ${IMAGE_ROOT}
           docker compose build ${{ matrix.IMAGE_VARIANT }}
 
       # TODO Push the Docker image to Google Artifact Registry

--- a/.github/workflows/singleuser.yml
+++ b/.github/workflows/singleuser.yml
@@ -1,6 +1,17 @@
 name: Build and Push to Google Artifact Registry
 # Adapted from http://acaird.github.io/computers/2020/02/11/github-google-container-cloud-run
 
+# TODO update env for G Artifact Registry project
+env:
+  GITHUB_SHA: ${{ github.sha }} 
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE_ROOT: singleuser
+  # TODO: eventually loop on image variant to build other services...
+  IMAGE_VARIANT: base
+  REGISTRY_HOSTNAME: gcr.io
+  PROJECT_ID: cuahsi-stacks-proj-id
+  HOST_REGION: us-east4-docker.pkg.dev
+  REPOSITORY: cuahsi
 
 on:
   push:
@@ -14,16 +25,6 @@ on:
 
 # Environment variables available to all jobs and steps in this workflow
 #  GKE_KEY: ${{ secrets.GKE_KEY }} 
-
-# TODO update env for G Artifact Registry project
-env:
-  GITHUB_SHA: ${{ github.sha }} 
-  GITHUB_REF: ${{ github.ref }} 
-  IMAGE: singleuser-base
-  REGISTRY_HOSTNAME: gcr.io
-  PROJECT_ID: cuahsi-stacks-proj-id
-  HOST_REGION: us-east4-docker.pkg.dev
-  REPOSITORY: cuahsi
 
 
 jobs:
@@ -48,7 +49,7 @@ jobs:
         echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
         echo ------------
         # export DOCKER_FULL_PATH="singleuser-base-${{ env.BUILD_DATE }}-$(echo ${GITHUB_REF} | cut -d'/' -f3)-${GITHUB_SHA}"
-        export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE}:${{ env.CUAHSI_BASE }}"
+        export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${IMAGE_VARIANT}:${{ env.CUAHSI_BASE }}"
         echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
         echo $DOCKER_FULL_PATH
 
@@ -71,11 +72,11 @@ jobs:
         gcloud auth configure-docker us-east4-docker.pkg.dev
 
     # Build the Docker image
-    # TODO: eventually we will build other services...
+    # TODO: eventually loop on image variant to build other services...
     - name: Build
       run: |
         cd singleuser
-        docker compose build base
+        docker compose build $IMAGE_VARIANT
     
     # TODO Push the Docker image to Google Artifact Registry
     - name: Push Docker Image to Artifact Registry

--- a/.github/workflows/singleuser.yml
+++ b/.github/workflows/singleuser.yml
@@ -1,11 +1,16 @@
-name: Build and Push to GCR
+name: Build and Push to Google Artifact Registry
+# Adapted from http://acaird.github.io/computers/2020/02/11/github-google-container-cloud-run
+
 
 on:
   push:
+    # TODO: build periodically? or on tag?
     # tags:
     #   - *
-    # TODO: run on tag publish
     branches: [ gh-actions-build ]
+    paths:
+      - "singleuser/**"
+      - ".github/workflows/**"
 
 # Environment variables available to all jobs and steps in this workflow
 #  GKE_KEY: ${{ secrets.GKE_KEY }} 
@@ -14,11 +19,11 @@ on:
 env:
   GITHUB_SHA: ${{ github.sha }} 
   GITHUB_REF: ${{ github.ref }} 
-  IMAGE: dendra-web-ui
+  IMAGE: singleuser-base
   REGISTRY_HOSTNAME: gcr.io
   PROJECT_ID: cuahsi-stacks-proj-id
   HOST_REGION: us-east4-docker.pkg.dev
-  REPOSITORY: cuahsi-stacks-repo
+  REPOSITORY: cuahsi
 
 
 jobs:
@@ -30,6 +35,24 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     
+    - name: Load .env file
+      uses: xom9ikk/dotenv@v2
+      with:
+        path: singleuser
+
+    - name: Echo env configuration and set image tag
+      id: tagging
+      run: |
+        echo "JH_BASE: ${{ env.JH_BASE }}"
+        echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
+        echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
+        echo ------------
+        # export DOCKER_FULL_PATH="singleuser-base-${{ env.BUILD_DATE }}-$(echo ${GITHUB_REF} | cut -d'/' -f3)-${GITHUB_SHA}"
+        export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE}:${{ env.CUAHSI_BASE }}"
+        echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
+        echo $DOCKER_FULL_PATH
+
+
     # TODO: enable google auth and add secrets to GH
     # - id: 'auth'
     #   uses: 'google-github-actions/auth@v1'
@@ -48,40 +71,13 @@ jobs:
         gcloud auth configure-docker us-east4-docker.pkg.dev
 
     # Build the Docker image
-    # - name: Build
-    #   run: |
-    #     export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
-    #     echo $TAG
-    #     docker build -t $IMAGE:latest \
-    #       --build-arg GITHUB_SHA="$GITHUB_SHA" \
-    #       --build-arg GITHUB_REF="$GITHUB_REF" \
-    #       -f Dockerfile-cuahsi .
-
     # TODO: eventually we will build other services...
     - name: Build
       run: |
         cd singleuser
-        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
-        echo $TAG
         docker compose build base
-
-
-    # Push the Docker image to Google Container Registry
-    # - name: Publish
-    #   run: |
-    #     export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
-    #     echo $TAG
-    #     docker tag $IMAGE:latest $REGISTRY_HOSTNAME/$PROJECT_ID/$IMAGE:latest
-    #     docker tag $IMAGE:latest $REGISTRY_HOSTNAME/$PROJECT_ID/$IMAGE:$TAG
-    #     docker push $REGISTRY_HOSTNAME/$PROJECT_ID/$IMAGE:latest
-    #     docker push $REGISTRY_HOSTNAME/$PROJECT_ID/$IMAGE:$TAG
     
     # TODO Push the Docker image to Google Artifact Registry
-    # - name: Push Docker Image to Artifact Registry
-    #   run: |
-    #     export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
-    #     echo $TAG
-    #     docker tag $IMAGE:latest $HOST_REGION/$PROJECT_ID/$REPOSITORY/$IMAGE:latest
-    #     docker tag $IMAGE:latest $HOST_REGION/$PROJECT_ID/$REPOSITORY/$IMAGE:$TAG
-    #     docker push $HOST_REGION/$PROJECT_ID/$REPOSITORY/$IMAGE:latest
-    #     docker push $HOST_REGION/$PROJECT_ID/$REPOSITORY/$IMAGE:$TAG
+    - name: Push Docker Image to Artifact Registry
+      run: |
+        docker push $HOST_REGION/$PROJECT_ID/${{ env.DOCKER_FULL_PATH }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,7 @@ env:
   REGISTRY_HOSTNAME: docker.io
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  # TODO: repo should be "cuahsi", hydroshare used for demonstration
-  REPOSITORY: hydroshare
+  REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
 
 on: push
 
@@ -32,17 +31,6 @@ jobs:
         uses: xom9ikk/dotenv@v2
         with:
           path: ${{ env.IMAGE_ROOT }}
-
-      - name: Echo env configuration and set image tag
-        id: tagging
-        run: |
-          echo "JH_BASE: ${{ env.JH_BASE }}"
-          echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
-          echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
-          echo ------------
-          export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
-          echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
-          echo $DOCKER_FULL_PATH
       
       - name: Docker Login
         run: |
@@ -55,7 +43,19 @@ jobs:
           docker compose build ${{ matrix.IMAGE_VARIANT }}
           docker image ls
 
+      - name: Echo env configuration and set image tag
+        id: tagging
+        run: |
+          echo "JH_BASE: ${{ env.JH_BASE }}"
+          echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
+          echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
+          echo ------------
+          export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
+          echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
+          echo $DOCKER_FULL_PATH
+          docker tag ${{ env.DOCKER_FULL_PATH }} ${{ env.DOCKER_FULL_PATH }}-test-$(date +'%Y-%m-%d')
+
       - name: Push Docker Image
         run: |
-          docker push ${{ env.DOCKER_FULL_PATH }}
+          docker push ${{ env.DOCKER_FULL_PATH }}-test-$(date +'%Y-%m-%d')
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ env:
   REGISTRY_HOSTNAME: docker.io
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  REPOSITORY: cuahsi
+  # TODO: repo should be "cuahsi", hydroshare used for demonstration
+  REPOSITORY: hydroshare
 
 on: push
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
-name: Periodically Build and Publish to Google Artifact Registry
-# Adapted from http://acaird.github.io/computers/2020/02/11/github-google-container-cloud-run
+name: Test build
 
-# TODO update env for CUAHSI
+# TODO remove test yaml
 env:
   GITHUB_SHA: ${{ github.sha }}
   GITHUB_REF: ${{ github.ref }}
@@ -11,25 +10,19 @@ env:
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   REPOSITORY: cuahsi
 
-on:
-  schedule:
-    - cron: '0 0 * * 0'  # At 00:00 every Sunday
+on: push
 
 jobs:
   setup-build-publish-deploy:
     name: Setup, Build, and Publish
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       max-parallel: 6
       # select a core set of images to build
       matrix:
         IMAGE_VARIANT:
-          - base
-          - scientific
-          - r
-          - summa
-          - wrfhydro
-          - csdms
+          - test
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -59,9 +52,9 @@ jobs:
         run: |
           cd "${IMAGE_ROOT}"
           docker compose build ${{ matrix.IMAGE_VARIANT }}
+          docker image ls
 
       - name: Push Docker Image
         run: |
           docker push ${{ env.DOCKER_FULL_PATH }}
 
-    # TODO: run tests?

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test build
 # TODO remove test yaml
 env:
   GITHUB_SHA: ${{ github.sha }}
-  GITHUB_REF: ${{ github.ref }}
+  GITHUB_REF: ${{ github.ref_name }}
   IMAGE_ROOT: singleuser
   REGISTRY_HOSTNAME: docker.io
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
@@ -41,7 +41,6 @@ jobs:
         run: |
           cd "${IMAGE_ROOT}"
           docker compose build ${{ matrix.IMAGE_VARIANT }}
-          docker image ls
 
       - name: Echo env configuration and set image tag
         id: tagging
@@ -50,12 +49,13 @@ jobs:
           echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
           echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
           echo ------------
-          export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
+          export DOCKER_TAG="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
+          export DOCKER_FULL_PATH="$DOCKER_TAG-test-$GITHUB_SHA"
           echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
           echo $DOCKER_FULL_PATH
-          docker tag ${{ env.DOCKER_FULL_PATH }} ${{ env.DOCKER_FULL_PATH }}-test-$(date +'%Y-%m-%d')
+          docker tag $DOCKER_TAG $DOCKER_FULL_PATH
 
       - name: Push Docker Image
         run: |
-          docker push ${{ env.DOCKER_FULL_PATH }}-test-$(date +'%Y-%m-%d')
+          docker push $DOCKER_FULL_PATH
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       
       - name: Docker Login
         run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USER --password-stdin
 
       # Build the Docker image
       - name: Build

--- a/.github/workflows/trigger-build-on-changes.yml
+++ b/.github/workflows/trigger-build-on-changes.yml
@@ -1,4 +1,4 @@
-name: Build and Publish to Google Artifact Registry on Github push
+name: Build and Publish to Registry on Github push
 
 env:
   GITHUB_SHA: ${{ github.sha }}
@@ -36,6 +36,7 @@ jobs:
     needs: detect-changes
     name: Setup, Build, and Publish
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       max-parallel: 6
       matrix:

--- a/.github/workflows/trigger-build-on-changes.yml
+++ b/.github/workflows/trigger-build-on-changes.yml
@@ -65,7 +65,7 @@ jobs:
       
       - name: Docker Login
         run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USER --password-stdin
 
       # Build the Docker image
       - name: Build

--- a/.github/workflows/trigger-build-on-changes.yml
+++ b/.github/workflows/trigger-build-on-changes.yml
@@ -9,7 +9,7 @@ env:
   REGISTRY_HOSTNAME: docker.io
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  REPOSITORY: cuahsi
+  REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
 
 on:
   push:

--- a/.github/workflows/trigger-build-on-changes.yml
+++ b/.github/workflows/trigger-build-on-changes.yml
@@ -1,23 +1,20 @@
 name: Build and Publish to Google Artifact Registry on Github push
 # Adapted from http://acaird.github.io/computers/2020/02/11/github-google-container-cloud-run
 
-# TODO update env for G Artifact Registry project
+# TODO update env for CUAHSI
 env:
   GITHUB_SHA: ${{ github.sha }}
   GITHUB_REF: ${{ github.ref }}
   IMAGE_ROOT: singleuser
-  REGISTRY_HOSTNAME: gcr.io
-  PROJECT_ID: cuahsi-stacks-proj-id
-  HOST_REGION: us-east4-docker.pkg.dev
+  REGISTRY_HOSTNAME: docker.io
+  DOCKER_USER: ${{ secrets.DOCKER_USER }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   REPOSITORY: cuahsi
 
 on:
   push:
     paths:
       - "singleuser/**"
-
-# Environment variables available to all jobs and steps in this workflow
-#  GKE_KEY: ${{ secrets.GKE_KEY }}
 
 jobs:
   detect-changes:
@@ -62,37 +59,23 @@ jobs:
           echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
           echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
           echo ------------
-          # export DOCKER_FULL_PATH="singleuser-base-${{ env.BUILD_DATE }}-$(echo ${GITHUB_REF} | cut -d'/' -f3)-${GITHUB_SHA}"
           export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
           echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
           echo $DOCKER_FULL_PATH
-
-      # TODO: enable google auth and add secrets to GH
-      # - id: 'auth'
-      #   uses: 'google-github-actions/auth@v1'
-      #   with:
-      #     credentials_json: '${{ secrets.GKE_KEY }}'
-
-      # - name: 'Set up Cloud SDK'
-      #   uses: 'google-github-actions/setup-gcloud@v1'
-
-      # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: |
-          # Set up docker to authenticate
-          # via gcloud command-line tool.
-          gcloud auth configure-docker --quiet
-          gcloud auth configure-docker $HOST_REGION
+      
+      - name: Docker Login
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
 
       # Build the Docker image
-      # TODO: eventually loop on image variant to build other services...
       - name: Build
         run: |
           cd "${IMAGE_ROOT}"
           docker compose build ${{ matrix.IMAGE_VARIANT }}
+          docker image ls
 
-      # TODO Push the Docker image to Google Artifact Registry
-      # - name: Push Docker Image to Artifact Registry
-      #   run: |
-      #     docker push $HOST_REGION/$PROJECT_ID/${{ env.DOCKER_FULL_PATH }}
+      - name: Push Docker Image
+        run: |
+          docker push ${{ env.DOCKER_FULL_PATH }}
 
     # TODO: run tests?

--- a/.github/workflows/trigger-build-on-changes.yml
+++ b/.github/workflows/trigger-build-on-changes.yml
@@ -1,0 +1,98 @@
+name: Build and Publish to Google Artifact Registry on Github push
+# Adapted from http://acaird.github.io/computers/2020/02/11/github-google-container-cloud-run
+
+# TODO update env for G Artifact Registry project
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE_ROOT: singleuser
+  REGISTRY_HOSTNAME: gcr.io
+  PROJECT_ID: cuahsi-stacks-proj-id
+  HOST_REGION: us-east4-docker.pkg.dev
+  REPOSITORY: cuahsi
+
+on:
+  push:
+    paths:
+      - "singleuser/**"
+
+# Environment variables available to all jobs and steps in this workflow
+#  GKE_KEY: ${{ secrets.GKE_KEY }}
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      # Expose matched filters as job 'variants' output variable
+      image_variants: ${{ steps.filter.outputs.changes }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2
+      # https://github.com/marketplace/actions/paths-changes-filter#conditional-execution
+      id: filter
+      with:
+        filters: |
+          base: ${{ env.IMAGE_ROOT }}/base/**
+          scientific: ${{ env.IMAGE_ROOT }}/python3-scientific/**
+          r: ${{ env.IMAGE_ROOT }}/r/**
+          summa: ${{ env.IMAGE_ROOT }}/python3-summa/**
+          wrfhydro: ${{ env.IMAGE_ROOT }}/python3-wrfhydro/**
+          csdms: ${{ env.IMAGE_ROOT }}/csdms-tools/**
+  setup-build-publish-deploy:
+    needs: detect-changes
+    name: Setup, Build, and Publish
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 6
+      matrix:
+        IMAGE_VARIANT: ${{ fromJSON(needs.detect-changes.outputs.image_variants) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v2
+        with:
+          path: ${{ env.IMAGE_ROOT }}
+
+      - name: Echo env configuration and set image tag
+        id: tagging
+        run: |
+          echo "JH_BASE: ${{ env.JH_BASE }}"
+          echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
+          echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
+          echo ------------
+          # export DOCKER_FULL_PATH="singleuser-base-${{ env.BUILD_DATE }}-$(echo ${GITHUB_REF} | cut -d'/' -f3)-${GITHUB_SHA}"
+          export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
+          echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
+          echo $DOCKER_FULL_PATH
+
+      # TODO: enable google auth and add secrets to GH
+      # - id: 'auth'
+      #   uses: 'google-github-actions/auth@v1'
+      #   with:
+      #     credentials_json: '${{ secrets.GKE_KEY }}'
+
+      # - name: 'Set up Cloud SDK'
+      #   uses: 'google-github-actions/setup-gcloud@v1'
+
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: |
+          # Set up docker to authenticate
+          # via gcloud command-line tool.
+          gcloud auth configure-docker --quiet
+          gcloud auth configure-docker $HOST_REGION
+
+      # Build the Docker image
+      # TODO: eventually loop on image variant to build other services...
+      - name: Build
+        run: |
+          cd "${IMAGE_ROOT}"
+          docker compose build ${{ matrix.IMAGE_VARIANT }}
+
+      # TODO Push the Docker image to Google Artifact Registry
+      # - name: Push Docker Image to Artifact Registry
+      #   run: |
+      #     docker push $HOST_REGION/$PROJECT_ID/${{ env.DOCKER_FULL_PATH }}
+
+    # TODO: run tests?

--- a/.github/workflows/trigger-build-on-changes.yml
+++ b/.github/workflows/trigger-build-on-changes.yml
@@ -1,10 +1,7 @@
 name: Build and Publish to Google Artifact Registry on Github push
-# Adapted from http://acaird.github.io/computers/2020/02/11/github-google-container-cloud-run
 
-# TODO update env for CUAHSI
 env:
   GITHUB_SHA: ${{ github.sha }}
-  GITHUB_REF: ${{ github.ref }}
   IMAGE_ROOT: singleuser
   REGISTRY_HOSTNAME: docker.io
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
@@ -51,17 +48,6 @@ jobs:
         uses: xom9ikk/dotenv@v2
         with:
           path: ${{ env.IMAGE_ROOT }}
-
-      - name: Echo env configuration and set image tag
-        id: tagging
-        run: |
-          echo "JH_BASE: ${{ env.JH_BASE }}"
-          echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
-          echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
-          echo ------------
-          export DOCKER_FULL_PATH="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
-          echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
-          echo $DOCKER_FULL_PATH
       
       - name: Docker Login
         run: |
@@ -72,7 +58,19 @@ jobs:
         run: |
           cd "${IMAGE_ROOT}"
           docker compose build ${{ matrix.IMAGE_VARIANT }}
-          docker image ls
+
+      - name: Echo env configuration and set image tag
+        id: tagging
+        run: |
+          echo "JH_BASE: ${{ env.JH_BASE }}"
+          echo "CUAHSI_BASE: ${{ env.CUAHSI_BASE }}"
+          echo "BUILD_DATE: ${{ env.BUILD_DATE }}"
+          echo ------------
+          export DOCKER_TAG="${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}"
+          export DOCKER_FULL_PATH="$DOCKER_TAG-$GITHUB_SHA"
+          echo "DOCKER_FULL_PATH=$DOCKER_FULL_PATH" >> $GITHUB_ENV
+          echo $DOCKER_FULL_PATH
+          docker tag $DOCKER_TAG $DOCKER_FULL_PATH
 
       - name: Push Docker Image
         run: |

--- a/singleuser/docker-compose.yml
+++ b/singleuser/docker-compose.yml
@@ -136,7 +136,7 @@ services:
   ####################
   # WRF-Hydro v5.0.3 #
   ####################
-  wrfhydro:
+  wrfhydro-5.0.3:
     env_file:
       - '.env'
     build:

--- a/singleuser/docker-compose.yml
+++ b/singleuser/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       labels:
         description: |
           Base JupyterHub image from which all other CUAHSI singleuser environments are created. Built using jupyterhub/singleuser:${JH_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-base:${CUAHSI_BASE}
+    image: ${REPOSITORY}/singleuser-base:${CUAHSI_BASE}
   
   ###################
   # Base Python 3.7 #
@@ -33,7 +33,7 @@ services:
       labels:
         description: |
           Base JupyterHub image from which all other CUAHSI singleuser environments are created. Built using jupyterhub/singleuser:${JH_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-base-py3.7:${CUAHSI_BASE}
+    image: ${REPOSITORY}/singleuser-base-py3.7:${CUAHSI_BASE}
   
   #################
   # Base CentOS 7 #
@@ -47,7 +47,7 @@ services:
       labels:
         description: |
           Base JupyterHub image from which all other CUAHSI singleuser environments are created in the CentOS7 operating system. Built using centos:centos7.7.1908 on ${BUILD_DATE}.
-    image: cuahsi/singleuser-base:centos7.${CUAHSI_BASE}
+    image: ${REPOSITORY}/singleuser-base:centos7.${CUAHSI_BASE}
 
   ##############
   # Scientific #
@@ -64,7 +64,7 @@ services:
       labels:
         description: |
           CUAHSI JupyterHub singleuser environment configured with scientific libraries. Built using cuahsi/jupyterhub-base:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-scientific-py3:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-scientific-py3:${BUILD_DATE}
 
   ##################
   # Scientific - R #
@@ -81,7 +81,7 @@ services:
       labels:
         description: |
           CUAHSI JupyterHub singleuser environment configured with scientific libraries with the R programming language. Built using cuahsi/jupyterhub-base:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-scientific-r:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-scientific-r:${BUILD_DATE}
 
   ##############################
   # 2020 Hydrogeology Syracuse #
@@ -97,7 +97,7 @@ services:
       labels:
         description: |
           CUAHSI JupyterHub singleuser environment configured with scientific libraries for Tao Wen's 2020 Hydrogeology course at Syracuse University. Built using cuahsi/singleuser-scientific-r:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-hydrogeology-r:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-hydrogeology-r:${BUILD_DATE}
 
   ######################
   # 2020 WHW - Seattle #
@@ -113,7 +113,7 @@ services:
       labels:
         description: |
           This environment is configured with scientific libraries for the 2020 Waterhackweek Cybertraining event. Built using cuahsi/singleuser-scientific-py3:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-waterhackweek:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-waterhackweek:${BUILD_DATE}
 
   ################################
   # 2018 Near Surface Geophysics #
@@ -130,7 +130,7 @@ services:
       labels:
         description: |
           CUAHSI JupyterHub singleuser environment configured for the 2019 Near Surface Geophysics Workshop. This image uses WINE to run R2, gmsh,and pyres. Built using cuahsi/singleuser-scientific-py3:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-geophysics:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-geophysics:${BUILD_DATE}
 
 
   ####################
@@ -148,7 +148,7 @@ services:
       labels:
         description: |
           Environment configured for WRF-Hydro v5.0.3. Built using cuahsi/singleuser-base:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-wrfhydro-py3:v5.0.3-${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-wrfhydro-py3:v5.0.3-${BUILD_DATE}
 
   ###########
   # Parflow #
@@ -165,7 +165,7 @@ services:
       labels:
         description: |
           Environment configured for Parflow. Built using cuahsi/singleuser-base:centos7.v${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-parflow:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-parflow:${BUILD_DATE}
 
   #########
   # SUMMA #
@@ -182,7 +182,7 @@ services:
       labels:
         description: |
           Environment configured for SUMMA. Built using cuahsi/singleuser-base:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-summa-py3:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-summa-py3:${BUILD_DATE}
 
   ###############
   # CSDMS TOOLS #
@@ -199,7 +199,7 @@ services:
       labels:
         description: |
           Environment configured for the Community Surface Dynamics Modeling System. Built using cuahsi/singleuser-base:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-csdms-tools:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-csdms-tools:${BUILD_DATE}
 
   #############
   # WRF-Hydro #
@@ -220,7 +220,7 @@ services:
       labels:
         description: |
           Environment configured for the NCAR WRF-Hydro model (nwm v2.0). Built using cuahsi/singleuser-base:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-wrfhydro:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-wrfhydro:${BUILD_DATE}
 
   #############
   #  SI-2021  #
@@ -237,7 +237,7 @@ services:
       labels:
         description: |
           Environment configured for the 2021 SI. Built using cuahsi/singleuser-base:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-si2021:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-si2021:${BUILD_DATE}
   
   #############
   #  MODFLOW  #
@@ -254,7 +254,7 @@ services:
       labels:
         description: |
           Environment configured to run MODFLOW for the 2021 IAH conference. Built using cuahsi/singleuser-base:${CUAHSI_BASE} on ${BUILD_DATE}.
-    image: cuahsi/singleuser-modflow:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-modflow:${BUILD_DATE}
   
   ###################
   #  EDU - Gerbrand #
@@ -268,4 +268,21 @@ services:
       args:
         # image version to use as base
         BASE_VERSION: ${CUAHSI_BASE}
-    image: cuahsi/singleuser-edu:${BUILD_DATE}
+    image: ${REPOSITORY}/singleuser-edu:${BUILD_DATE}
+
+  ########
+  # Test #
+  ########
+  test:
+    env_file:
+      - '.env'
+    build: 
+      context: ./test
+      dockerfile: Dockerfile.test
+      args:
+        # JupyterHub/singleuser version to use as base
+        BASE_VERSION: ${JH_BASE}
+      labels:
+        description: |
+          Test JupyterHub image. Built using jupyterhub/singleuser:${JH_BASE} on ${BUILD_DATE}.
+    image: ${REPOSITORY}/singleuser-test:${CUAHSI_BASE}

--- a/singleuser/test/Dockerfile.test
+++ b/singleuser/test/Dockerfile.test
@@ -1,0 +1,19 @@
+# derived from the minimal singleuser image 
+
+ARG BASE_VERSION
+FROM jupyterhub/singleuser:$BASE_VERSION
+
+MAINTAINER Tony Castronova <acastronova@cuahsi.org>
+
+USER $NB_UID
+
+# set the home dir
+ENV HOME=/home/$NB_USER/data
+
+# set the default terminal start path to $HOME
+RUN echo 'cd $HOME' >> .profile
+
+# remove work dir b/c we're using "data"
+RUN rm -rf ~/work
+
+USER jovyan

--- a/singleuser/test/README.md
+++ b/singleuser/test/README.md
@@ -1,0 +1,4 @@
+
+# Test JupyterHub Singleuser Image
+
+This is the test singleuser image for the CUAHSI JupyterHub platform. The purpose of this image is for testing builds


### PR DESCRIPTION
NOTE: this PR is based on `develop` instead of master/main

Adds three workflows
1. [periodic-image-build](https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/.github/workflows/periodic-image-build.yml) will build our [core set of images](https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/.github/workflows/periodic-image-build.yml#L31C3-L36) every Sunday at midnight

2. [trigger-build-on-changes](https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/.github/workflows/trigger-build-on-changes.yml) will build any subset of the same (as above) [core images](https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/.github/workflows/periodic-image-build.yml#L31C3-L36) if there are changes in the `singleuser/**` directory. Example: if I modify `singleuser/base/Dockerfile.base` and push the commit to GH, this workflow will build that **singleuser-base** image.

3. [test build](https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/.github/workflows/test.yml) primarily for demonstration purposes. Builds a [JH base image with no additions](https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/singleuser/test/Dockerfile.test), to show that failed workflows are due to our Dockerfiles, not to the base JH image.

---
### TODO before merge
There are some "todos" in the workflows.
Right now, for demonstration, the test workflow is set to publish here:
https://hub.docker.com/repository/docker/hydroshare/singleuser-test/
This test workflow is functional, see this run:
https://github.com/CUAHSI/cuahsi-stacks/actions/runs/5524694888/jobs/10077340136
Which published this image:
https://hub.docker.com/layers/hydroshare/singleuser-test/2022.08.09-test-6ee4213b68beffca882a3804cc07bc81428a260f/images/sha256-e86c0ccb6d4d9e2076c676e7e9577927115e1b5d17e4bb4333591bc75994c5d8?context=repo

We need to edit three GH secrets values for Docker Hub. That can be done here:
https://github.com/CUAHSI/cuahsi-stacks/settings/secrets/actions
`DOCKER_PASSWORD` should be set to a Docker Hub token
`DOCKER_USER` should be the username in Docker Hub
`DOCKER_REPOSITORY` should be the dockerhub repo


Then images will be published into the Registry!

Another remaining item is vetting how the images are tagged.
As this PR currently stands, images are tagged using the following when triggered by push with changes:
`${REPOSITORY}/${IMAGE_ROOT}-${{ matrix.IMAGE_VARIANT }}:${{ env.CUAHSI_BASE }}-COMMIT_SHA`
https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/.github/workflows/trigger-build-on-changes.yml#L70

For example, that will result in `cuahsi/singleuser-base:2022.08.09-6ee4213b68beffca882a3804cc07bc81428a260f`
This differs from the tagging scheme that is currently used in the [cuahsi org](https://hub.docker.com/r/cuahsi/singleuser-base/tags). I did this so successive builds will not overwrite the existing images. This is because the [.env values](https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/singleuser/.env#L2-L3) have to be manually edited in order to change the current production tags.

For periodic builds, the images are tagged in the workflow using
https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/.github/workflows/periodic-image-build.yml#L56
which results in something like `cuahsi/singleuser-base:2022.08.09-periodic-2023.07.11`

---

### Future optimization
There is duplication between the workflow files and we could optimize a bit by [reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow), but I'm not too familiar with that so didn't take it on yet.

Another place for optimization: right now, the two lists of directories to build:
1. https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/.github/workflows/trigger-build-on-changes.yml#L35-L40
2. https://github.com/CUAHSI/cuahsi-stacks/blob/gh-actions-build/.github/workflows/periodic-image-build.yml#L31-L36
are just maintained as _static_ lists in two separate places. Not ideal. If you add a new directory in `singleuser` and want it to be monitored for periodic building, you have to add it to the appropriate list. It would be great to dynamically create this list of monitored folders. I tried some options (`git diff --dirstat=files,0 HEAD~1 ${{ env.IMAGE_ROOT }}` etc) but ultimately couldn't easily get the list to expand into usable yaml dictionaries...so perhaps static lists for now.

We should use GH action cache to speed up the builds:
https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
https://github.com/docker/build-push-action/

And a final place for optimization is to have the GH workflows run automated/unit tests on the images.